### PR TITLE
CI: pin jsonschema<4.0 for testing speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,5 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pip install pytest IPython
+        pip install pytest IPython "jsonschema<4.0"
         pytest --doctest-modules altair_viewer


### PR DESCRIPTION
jsonschema 4.0 introduced a performance regression that makes CI testing time for altair_saver go from ~30 seconds to >20 minutes. (related to https://github.com/Julian/jsonschema/issues/853) This pins jsonschema<4.0 to improve CI turnaround.

Example CI runs:
- with latest jsonschema: https://github.com/altair-viz/altair_viewer/runs/4083468674
-  with this PR: https://github.com/altair-viz/altair_viewer/runs/4083698040